### PR TITLE
Fix uppercase query support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,17 +32,18 @@
     "all": true
   },
   "dependencies": {
+    "base32.js": "^0.1.0",
     "bluebird": "^3.5.0",
     "bunyan": "^1.8.12",
     "cuid": "^1.3.8",
     "ejs": "^2.5.6",
     "express": "^4.15.2",
+    "opencollective": "^1.0.3",
     "opencollective-postinstall": "^2.0.0",
     "parse-domain": "^1.1.0",
     "pm2": "^2.6.1",
     "redis": "^2.7.1",
-    "vhost": "^3.0.2",
-    "opencollective": "^1.0.3"
+    "vhost": "^3.0.2"
   },
   "devDependencies": {
     "all-contributors-cli": "^5.4.1",

--- a/src/services/redirect.service.js
+++ b/src/services/redirect.service.js
@@ -1,5 +1,6 @@
 const config = require('../config')
 const LoggerHandler = require('../handlers/logger.handler')
+const base32 = require('base32.js')
 
 module.exports = class RedirectService {
   constructor(req) {
@@ -18,7 +19,7 @@ module.exports = class RedirectService {
       https: false,
       slashs: [],
       status: 301,
-      queries: [],
+      query: '',
     }
 
     let r
@@ -43,13 +44,10 @@ module.exports = class RedirectService {
       this.logger.info(`${path} ${hostname} without .opts-statuscode-${r[1]}`)
     }
 
-    while ((r = hostname.match(/(\.(?:opts-query)\.)(.*?)(?:(?:\.(?:opts-eq|eq)\.?)(.*?))?(?:(?:\.|$))/))) {
+    if ((r = hostname.match(/(\.(?:opts-query)\.)(.*?)(?:(?:\.|$))/))) {
       hostname = hostname.replace(r[0], '')
-      if (r[3]) {
-        options.queries.push(`${r[2]}=${r[3]}`)
-      } else {
-        options.queries.push(`${r[2]}`)
-      }
+      options.query = base32.decode(r[2])
+
       this.logger.info(`${path} ${hostname} without ${r[0]}`)
     }
 
@@ -76,7 +74,7 @@ module.exports = class RedirectService {
 
     let urlPath = ''
     if (options.slashs.length >= 1) urlPath += `/${options.slashs.join('/')}`
-    if (options.queries.length >= 1) urlPath += `?${options.queries.join('&')}`
+    if (options.query.length >= 1) urlPath += `?${options.query}`
     if (options.uri === true) urlPath += this.req.url
 
     return {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -314,9 +314,17 @@
             </span>
             <br />
             <span class="label label-danger en">PARAMETER</span>
-            <span class="en mb-15">
-              The <code>.opts-query.&lt;base32-encoded-query&gt;</code> parameter is responsible to turning query params of <code>?&lt;query&gt;</code> to canonical domain name. You have to encode your query using RFC 4648 Base32
+            <span class="label label-danger pt-br">PARÂMETRO</span>
+            <span class="en">
+              The <code>.opts-query.&lt;base32-encoded-query&gt;</code> parameter is responsible to turning query params
+              of <code>?&lt;query&gt;</code> to canonical domain name. You have to encode your query using RFC 4648 Base32
               encoding and remove all trailing <code>=</code> characters. You can use the converter below to do that.
+            </span>
+            <span class="pt-br">
+              O parâmetro <code>.opts-query.&lt;base32-encoded-query&gt;</code> é responsável por transformar os parâmetros
+              de consulta <code>?&lt;query&gt;</code> em um nome de domínio canônico. Você deve codificar sua consulta usando
+              a codificação RFC 4648 Base32 e remover todos os caracteres <code>=</code> que aparecem no final da linha.
+              Você pode usar o conversor abaixo para fazer isso.
             </span>
             <br />
             <br />

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,6 +12,7 @@
   <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js"></script>
+  <script src="https://unpkg.com/base32.js@0.1.0/dist/base32.min.js"></script>
   <style>
     body { background-color: #F8F8F8; }
 
@@ -314,7 +315,8 @@
             <br />
             <span class="label label-danger en">PARAMETER</span>
             <span class="en mb-15">
-              The <code>.opts-query.&lt;key&gt;opts-eq.&lt;value&gt;</code> parameter is responsible to turning query params of <code>?&lt;key&gt;=&lt;value&gt;</code> to canonical domain name. 
+              The <code>.opts-query.&lt;base32-encoded-query&gt;</code> parameter is responsible to turning query params of <code>?&lt;query&gt;</code> to canonical domain name. You have to encode your query using RFC 4648 Base32
+              encoding and remove all trailing <code>=</code> characters. You can use the converter below to do that.
             </span>
             <br />
             <br />
@@ -499,9 +501,9 @@
 
         return url.hostname
           + url.pathname.replace(/\//g, '.opts-slash.').replace(/([^.])$/, '$1.')
-          + Array.from(new URLSearchParams(url.search).entries())
-            .map(([key, value]) => `opts-query.${key}.` + (value ? `opts-eq.${value}.` : ''))
-            .join('')
+          + (url.search
+            ? `opts-query.${base32.encode(new TextEncoder().encode(url.search.slice(1)), { type: 'rfc4648', lc: true })}.` 
+            : '')
           + (url.protocol === 'https:' ? 'opts-https.' : '')
           + '<%= config.fqdn %>.'
       }


### PR DESCRIPTION
PR #37 added support for query params, however, as DNS spec doesn't care about upper and lower case the case wasn't preserved. This PR tries to solve that issue by encoding query string to some encoding which is supported by DNS. I chose base32 RFC 4648  which uses Latin alphanumeric symbols. 
This solution has one limitation - the resulted string can be long and don't feed to some providers DNS zone settings. 